### PR TITLE
fix: zip ファイルの生成前にリポジトリの状態をクリアするように

### DIFF
--- a/scripts/generate_zips.ts
+++ b/scripts/generate_zips.ts
@@ -48,6 +48,7 @@ const templateListJsonBaseUrl = "https://github.com/akashic-contents/templates/r
 });
 
 async function generateZip(cwd: string, dir: string, name: string, output: string): Promise<any> {
+	await exec(`git clean -xdf`, { cwd, encoding: "utf-8" });
 	await exec(`zip -r ${name} ${dir}`, { cwd, encoding: "utf-8" });
 	await exec(`mv ${name} ${output}`, { cwd, encoding: "utf-8" });
 }


### PR DESCRIPTION
## このPullRequestが解決する内容

各テンプレート内の `node_modules` や `coverage` 等が zip ファイルに含まれてしまっていたため、 zip ファイルの生成前にリポジトリの状態をクリアするようにします。