### PR TITLE
fix: 成果物の生成時にテンプレート内のディレクトリを削除しないように

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Run test
         run: |
           npm ci
+          npm run generate
           npm test

--- a/scripts/generate_zips.ts
+++ b/scripts/generate_zips.ts
@@ -48,7 +48,6 @@ const templateListJsonBaseUrl = "https://github.com/akashic-contents/templates/r
 });
 
 async function generateZip(cwd: string, dir: string, name: string, output: string): Promise<any> {
-	await exec(`git clean -xdf`, { cwd, encoding: "utf-8" });
-	await exec(`zip -r ${name} ${dir}`, { cwd, encoding: "utf-8" });
+	await exec(`zip -r ${name} ${dir} -x "*node_modules*"`, { cwd, encoding: "utf-8" });
 	await exec(`mv ${name} ${output}`, { cwd, encoding: "utf-8" });
 }


### PR DESCRIPTION
## このPullRequestが解決する内容
成果物の生成時にテンプレート内のディレクトリを削除しないようにします。
これにより `npm run generate` 後に `npm test` が実行できなくなる問題が修正されます。