### PR TITLE
fix: 成果物生成後にテストを実行するように修正

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -21,8 +21,8 @@ jobs:
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           npm ci
-          npm test
           npm run generate
+          npm test
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## このPullRequestが解決する内容

#75 にて成果物生成前にテストを実行するとエラーになるように修正した結果、 deploy のワークフローが失敗してしまうことがわかりました。
そのため deploy のワークフローにて成果物生成後にテストを実行するように修正します。

自明な変更のためセルフマージします。