### PR TITLE
chore: fs/promises のインポートパスを修正

### DIFF
--- a/tests/check_distribution.spec.ts
+++ b/tests/check_distribution.spec.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs/promises";
+import { promises as fs } from "fs";
 import * as path from "path";
 import * as jszip from "jszip";
 


### PR DESCRIPTION
## このPullRequestが解決する内容
#75 にて修正した `fs/promises` のインポートパスの修正に漏れがあったため追加で修正します。
すでにレビュー済みの内容のためセルフマージします。