### PR TITLE
feat(test): 各テンプレートの npm-scripts を実行するテストを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         id: variables
         run: |
           TODAY=$(date '+%Y-%m-%d')
-          echo "::set-output name=today::$TODAY"
+          echo "today=${TODAY}" >> $GITHUB_OUTPUT
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*.zip"

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ npm run generate
 npm run generate
 npm test
 ```
+
+環境変数 `NODE_ENV` に `"debug"` を指定することでコマンドテストの実行結果を標準出力へ出力します。
+
+```sh
+# Linux の場合
+NODE_ENV=debug npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
       "devDependencies": {
         "@types/jest": "^29.1.1",
         "@types/node": "^18.7.23",
+        "@types/node-fetch": "^2.6.2",
         "jest": "^29.1.1",
         "jszip": "^3.10.1",
         "lerna": "^6.0.0",
+        "node-fetch": "^2.6.7",
         "npm-run-all": "^4.1.5",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
@@ -3043,6 +3045,16 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -3343,6 +3355,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/at-least-node": {
@@ -4051,6 +4069,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -4428,6 +4458,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -4950,6 +4989,20 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-constants": {
@@ -7534,6 +7587,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -13745,6 +13819,16 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -13989,6 +14073,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "at-least-node": {
@@ -14509,6 +14599,15 @@
         "wcwidth": "^1.0.0"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "common-ancestor-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
@@ -14810,6 +14909,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -15215,6 +15320,17 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -17171,6 +17287,21 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "generate": "run-s generate:**",
     "generate:zips": "ts-node ./scripts/generate_zips.ts",
     "test": "run-s test:**",
-    "test:jest": "jest",
-    "test:workspaces": "lerna run test"
+    "test:jest": "jest --forceExit"
   },
   "repository": {
     "type": "git",
@@ -24,9 +23,11 @@
   "devDependencies": {
     "@types/jest": "^29.1.1",
     "@types/node": "^18.7.23",
+    "@types/node-fetch": "^2.6.2",
     "jest": "^29.1.1",
     "jszip": "^3.10.1",
     "lerna": "^6.0.0",
+    "node-fetch": "^2.6.7",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
@@ -37,6 +38,9 @@
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
       "<rootDir>/templates/"
+    ],
+    "testMatch": [
+      "<rootDir>/tests/*.spec.ts"
     ]
   }
 }

--- a/templates/typescript-minimal/.gitignore
+++ b/templates/typescript-minimal/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 /script
+/game
 coverage
+game.zip

--- a/templates/typescript-minimal/game.json
+++ b/templates/typescript-minimal/game.json
@@ -13,5 +13,6 @@
 	"moduleMainScripts": {},
 	"environment": {
 		"sandbox-runtime": "3"
-	}
+	},
+	"globalScripts": []
 }

--- a/templates/typescript-minimal/package-lock.json
+++ b/templates/typescript-minimal/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "typescript-minimal-game-sample",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "@akashic/akashic-cli-export": "^1.7.51",
         "@akashic/akashic-cli-scan": "^0.15.46",

--- a/templates/typescript-shin-ichiba-ranking/.gitignore
+++ b/templates/typescript-shin-ichiba-ranking/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 /script
+/game
 coverage
+game.zip

--- a/templates/typescript-shin-ichiba-ranking/game.json
+++ b/templates/typescript-shin-ichiba-ranking/game.json
@@ -46,5 +46,6 @@
 				"ranking"
 			]
 		}
-	}
+	},
+	"globalScripts": []
 }

--- a/templates/typescript-shin-ichiba-ranking/package-lock.json
+++ b/templates/typescript-shin-ichiba-ranking/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "typescript-shin-ichiba-ranking-game-sample",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "@akashic/akashic-cli-export": "^1.7.51",
         "@akashic/akashic-cli-scan": "^0.15.46",

--- a/templates/typescript-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/templates/typescript-shin-ichiba-ranking/src/_bootstrap.ts
@@ -1,6 +1,6 @@
 // 通常このファイルを編集する必要はありません。ゲームの処理は main.js に記述してください
-import { GameMainParameterObject, RPGAtsumaruWindow } from "./parameterObject";
 import { main } from "./main";
+import { GameMainParameterObject, RPGAtsumaruWindow } from "./parameterObject";
 
 declare const window: RPGAtsumaruWindow;
 

--- a/templates/typescript/.gitignore
+++ b/templates/typescript/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 /script
+/game
 coverage
+game.zip

--- a/templates/typescript/game.json
+++ b/templates/typescript/game.json
@@ -31,5 +31,6 @@
 	"moduleMainScripts": {},
 	"environment": {
 		"sandbox-runtime": "3"
-	}
+	},
+	"globalScripts": []
 }

--- a/templates/typescript/package-lock.json
+++ b/templates/typescript/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "typescript-game-sample",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "devDependencies": {
         "@akashic/akashic-cli-export": "^1.7.51",
         "@akashic/akashic-cli-scan": "^0.15.46",

--- a/tests/check_distribution.spec.ts
+++ b/tests/check_distribution.spec.ts
@@ -1,28 +1,28 @@
-import { promises as fs } from "fs";
+import * as fs from "fs";
 import * as path from "path";
 import * as jszip from "jszip";
 
 const templateDir = path.join(__dirname, "..", "dist");
 
+const templateZipPaths = fs.readdirSync(templateDir, { withFileTypes: true })
+	.filter(dirent => dirent.isFile() && path.extname(dirent.name) === ".zip")
+	.map(dirent => path.join(templateDir, dirent.name));
+
+if (!templateZipPaths || !templateZipPaths.length) {
+	throw new Error("distribution does not exist.");
+}
+
 describe("check distribution", () => {
-	it("check the directory structure of the distribution", async () => {
-		const templateZipPaths = (await fs.readdir(templateDir, { withFileTypes: true }))
-			.filter(dirent => dirent.isFile() && path.extname(dirent.name) === ".zip")
-			.map(dirent => path.join(templateDir, dirent.name));
+	for (let templateZipPath of templateZipPaths) {
+		const name = path.basename(templateZipPath, path.extname(templateZipPath)); // /path/to/javascript.zip -> javascript
 
-		if (!templateZipPaths || !templateZipPaths.length) {
-			throw new Error("distribution does not exist.");
-		}
-
-		for (let templateZipPath of templateZipPaths) {
-			const data = await fs.readFile(templateZipPath);
+		it(`check the directory structure of the "${name}"`, async () => {
+			const data = fs.readFileSync(templateZipPath);
 			const zip = await jszip.loadAsync(data);
-			const name = path.basename(templateZipPath, path.extname(templateZipPath)); // /path/to/javascript.zip -> javascript
-
 			// root にテンプレート名のディレクトリが存在することを確認
 			expect(zip.files[name + "/"]).not.toBeUndefined();
 			// テンプレート名のディレクトリ直下に game.json が存在することを確認
 			expect(zip.files[name + "/game.json"]).not.toBeUndefined();
-		}
-	});
+		});
+	}
 });

--- a/tests/check_npm_commands.spec.ts
+++ b/tests/check_npm_commands.spec.ts
@@ -88,7 +88,7 @@ const typescriptCommands: Command[] = [
 			const index = await fsPromise.stat(join(path, "game", "index.html"));
 			return stat.isDirectory() && index.isFile();
 		}
-	},
+	}
 ];
 
 const templates: Template[] = [

--- a/tests/check_npm_commands.spec.ts
+++ b/tests/check_npm_commands.spec.ts
@@ -1,0 +1,237 @@
+import * as childProcess from "child_process";
+import fetch from "node-fetch";
+import * as fs from "fs";
+import * as fsPromise from "fs/promises";
+import { join } from "path";
+
+// 一つのテストのタイムアウト時間
+const TIMEOUT_JEST = 60000;
+
+// 一つのコマンドのタイムアウト時間
+const TIMEOUT_COMMAND = 30000;
+
+interface Template {
+	dir: string;
+	commandMap: {[path: string]: Command[]};
+}
+
+interface Command {
+	/**
+	 * 実行するコマンド。
+	 */
+	command: string;
+	/**
+	 * コマンドの引数。
+	 */
+	args: string[];
+	/**
+	 * コマンドのタイムアウト時間のミリ秒。
+	 */
+	timeout?: number;
+	/**
+	 * コマンドの中止条件。
+	 * npm start など自発的に終了しないコマンドでのみ有効。
+	 */
+	until?: () => Promise<boolean>;
+	/**
+	 * コマンドの実行終了後に実行される成功条件。
+	 */
+	post?: (path: string) => Promise<boolean>;
+}
+
+const javascriptCommands: Command[] = [
+	{
+		command: "npm",
+		args: ["ci"],
+		timeout: 15000
+	},
+	{
+		command: "npm",
+		args: ["install"],
+		timeout: 15000
+	},
+	{
+		command: "npm",
+		args: ["start"],
+		until: checkSandboxRunning,
+		timeout: 10000
+	},
+	{
+		command: "npm",
+		args: ["run", "lint"],
+		timeout: 10000
+	}
+];
+
+const typescriptCommands: Command[] = [
+	...javascriptCommands,
+	{
+		command: "npm",
+		args: ["run", "build"],
+		timeout: 10000
+	},
+	{
+		command: "npm",
+		args: ["run", "update"],
+		timeout: 10000
+	},
+	{
+		command: "npm",
+		args: ["test"],
+		timeout: 10000
+	},
+	{
+		command: "npm",
+		args: ["run", "export-zip"],
+		timeout: 10000,
+		post: async (path) => {
+			const stat = await fsPromise.stat(join(path, "game.zip"));
+			return stat.isFile() && 0 < stat.size;
+		}
+	},
+	{
+		command: "npm",
+		args: ["run", "export-html"],
+		timeout: 10000,
+		post: async (path) => {
+			const stat = await fsPromise.stat(join(path, "game"));
+			const index = await fsPromise.stat(join(path, "game", "index.html"));
+			return stat.isDirectory() && index.isFile();
+		}
+	},
+];
+
+const templates: Template[] = [
+	{
+		dir: "templates",
+		commandMap: {
+			"javascript": javascriptCommands,
+			"javascript-minimal": javascriptCommands,
+			"javascript-shin-ichiba-ranking": javascriptCommands,
+			"typescript": typescriptCommands,
+			"typescript-minimal": typescriptCommands,
+			"typescript-shin-ichiba-ranking": typescriptCommands,
+		}
+	}
+];
+
+for (const { dir, commandMap } of templates) {
+	const templateDirs = (fs.readdirSync(dir, { withFileTypes: true }))
+		.filter(dirent => dirent.isDirectory())
+		.map(dirent => dirent.name);
+
+	for (const templateDir of templateDirs) {
+		const commands = commandMap[templateDir];
+		const templateRelativeDir = join(dir, templateDir);
+
+		if (!commands) {
+			throw new Error(`commands of ${templateRelativeDir} not found`);
+			// continue;
+		}
+
+		describe(`check npm commands in ${templateRelativeDir}`, () => {
+			for (const command of commands) {
+				const slug = `${command.command} ${command.args.join(" ")}`;
+				const label = `${templateRelativeDir}: ${slug}`
+				it(`test "${label}"`, async () => {
+					const exitCode = await testWithCommand(templateRelativeDir, command);
+					expect(exitCode).toBe(0);
+				}, TIMEOUT_JEST);
+			}
+		});
+	}
+}
+
+async function testWithCommand(path: string, { command, args, timeout, until, post }: Command): Promise<number> {
+	let exitCode: number = 0;
+
+	const p = childProcess.spawn(
+		command,
+		args,
+		{
+			cwd: path,
+			detached: false,
+			timeout: timeout ?? TIMEOUT_COMMAND
+		}
+	);
+	p.stdout.on("data", (data) => {
+		// console.log(data.toString());
+	});
+	p.stderr.on("data", (data) => {
+		// console.log(data.toString());
+	});
+
+	if (until) {
+		try {
+			await waitUntil(1000, until);
+		} catch (e: any) {
+			console.log(e.message);
+			exitCode = 1;
+		} finally {
+			p.kill();
+		}
+	} else {
+		try {
+			// プロセスの終了 (0 <= process.exitCode となる) まで待機
+			await waitUntil(100, async () => p.exitCode != null, TIMEOUT_COMMAND);
+		} catch (e: any) {
+			p.kill();
+		}
+		exitCode = p.exitCode!;
+	}
+
+	if (!p.killed) {
+		// この時点で終了していなければ強制的に終了させる
+		p.stdout.destroy();
+		p.stderr.destroy();
+		p.kill("SIGKILL");
+	}
+
+	if (post) {
+		try {
+			const ret = await post(path);
+			if (!ret) {
+				throw new Error(`failed to execute post script in ${path}`);
+			}
+		} catch (e: any) {
+			console.log(e.message);
+			exitCode = 1;
+		}
+	}
+
+	return exitCode;
+}
+
+function waitUntil(interval: number, callback: () => Promise<boolean>, timeout: number = TIMEOUT_JEST) {
+	const now = Date.now();
+	const until = now + timeout;
+	return new Promise<void>((resolve, reject) => {
+		const timer = setInterval(async () => {
+			try {
+				if (await callback()) {
+					clearInterval(timer);
+					resolve();
+				}
+				if (until < Date.now()) {
+					throw new Error("waitUntil(): process timeout");
+				}
+			} catch (e) {
+				clearInterval(timer);
+				reject(e);
+			}
+		}, interval);
+	});
+}
+
+/**
+ * akashic-sandbox が立ち上がっているかを確認する簡易スクリプト。
+ * ポートは 3000 番で固定。
+ */
+async function checkSandboxRunning(): Promise<boolean> {
+	try {
+		const res = await fetch("http://localhost:3000");
+		return res.ok;
+	} catch (e) {
+		return false;
+	}
+}

--- a/tests/check_npm_commands.spec.ts
+++ b/tests/check_npm_commands.spec.ts
@@ -25,10 +25,6 @@ interface Command {
 	 */
 	args: string[];
 	/**
-	 * コマンドのタイムアウト時間のミリ秒。
-	 */
-	timeout?: number;
-	/**
 	 * コマンドの中止条件。
 	 * npm start など自発的に終了しないコマンドでのみ有効。
 	 */
@@ -43,23 +39,19 @@ const javascriptCommands: Command[] = [
 	{
 		command: "npm",
 		args: ["ci"],
-		timeout: 15000
 	},
 	{
 		command: "npm",
 		args: ["install"],
-		timeout: 15000
 	},
 	{
 		command: "npm",
 		args: ["start"],
 		until: checkSandboxRunning,
-		timeout: 10000
 	},
 	{
 		command: "npm",
 		args: ["run", "lint"],
-		timeout: 10000
 	}
 ];
 
@@ -68,22 +60,18 @@ const typescriptCommands: Command[] = [
 	{
 		command: "npm",
 		args: ["run", "build"],
-		timeout: 10000
 	},
 	{
 		command: "npm",
 		args: ["run", "update"],
-		timeout: 10000
 	},
 	{
 		command: "npm",
 		args: ["test"],
-		timeout: 10000
 	},
 	{
 		command: "npm",
 		args: ["run", "export-zip"],
-		timeout: 10000,
 		post: async (path) => {
 			const stat = await fsPromise.stat(join(path, "game.zip"));
 			return stat.isFile() && 0 < stat.size;
@@ -92,7 +80,6 @@ const typescriptCommands: Command[] = [
 	{
 		command: "npm",
 		args: ["run", "export-html"],
-		timeout: 10000,
 		post: async (path) => {
 			const stat = await fsPromise.stat(join(path, "game"));
 			const index = await fsPromise.stat(join(path, "game", "index.html"));
@@ -142,7 +129,7 @@ for (const { dir, commandMap } of templates) {
 	}
 }
 
-async function testWithCommand(path: string, { command, args, timeout, until, post }: Command): Promise<number> {
+async function testWithCommand(path: string, { command, args, until, post }: Command): Promise<number> {
 	let exitCode: number = 0;
 
 	const p = childProcess.spawn(
@@ -151,7 +138,7 @@ async function testWithCommand(path: string, { command, args, timeout, until, po
 		{
 			cwd: path,
 			detached: false,
-			timeout: timeout ?? TIMEOUT_COMMAND
+			timeout: TIMEOUT_COMMAND
 		}
 	);
 	p.stdout.on("data", (data) => {

--- a/tests/check_npm_commands.spec.ts
+++ b/tests/check_npm_commands.spec.ts
@@ -116,7 +116,7 @@ for (const { dir, commandMap } of templates) {
 
 		if (!commands) {
 			if (isDebug) {
-				console.warn(`commands of ${templateRelativeDir} not found, but skipping`);
+				console.warn(`commands of ${templateRelativeDir} not found, but skipped`);
 				continue;
 			}
 			throw new Error(`commands of ${templateRelativeDir} not found`);


### PR DESCRIPTION
# このPullRequestが解決する内容
* 各テンプレートの npm-scripts を実行するテストを追加します。
* GitHub Actions の set-output を `$GITHUB_OUTPUT` へ出力するように修正します。
  * https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* 既存テスト (`tests/check_distribution.spec.ts`) を一部修正
  * テスト内容に変更はありません