### PR TITLE
fix: fix broken lint caused by ESM migration

### DIFF
--- a/templates/typescript-minimal/eslint.config.mjs
+++ b/templates/typescript-minimal/eslint.config.mjs
@@ -1,10 +1,10 @@
-const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-const importPlugin = require("eslint-plugin-import");
-const globals = require("globals");
-const tsParser = require("@typescript-eslint/parser");
-const stylisticTs = require("@stylistic/eslint-plugin-ts");
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
+import globals from "globals";
+import tsParser from "@typescript-eslint/parser";
+import stylisticTs from "@stylistic/eslint-plugin-ts";
 
-module.exports = [
+export default [
   {
     ignores: ["**/*.js"],
   },

--- a/templates/typescript-shin-ichiba-ranking/eslint.config.mjs
+++ b/templates/typescript-shin-ichiba-ranking/eslint.config.mjs
@@ -1,10 +1,10 @@
-const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-const importPlugin = require("eslint-plugin-import");
-const globals = require("globals");
-const tsParser = require("@typescript-eslint/parser");
-const stylisticTs = require("@stylistic/eslint-plugin-ts");
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
+import globals from "globals";
+import tsParser from "@typescript-eslint/parser";
+import stylisticTs from "@stylistic/eslint-plugin-ts";
 
-module.exports = [
+export default [
   {
     ignores: ["**/*.js"],
   },

--- a/templates/typescript/eslint.config.mjs
+++ b/templates/typescript/eslint.config.mjs
@@ -1,10 +1,10 @@
-const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-const importPlugin = require("eslint-plugin-import");
-const globals = require("globals");
-const tsParser = require("@typescript-eslint/parser");
-const stylisticTs = require("@stylistic/eslint-plugin-ts");
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
+import globals from "globals";
+import tsParser from "@typescript-eslint/parser";
+import stylisticTs from "@stylistic/eslint-plugin-ts";
 
-module.exports = [
+export default [
   {
     ignores: ["**/*.js"],
   },


### PR DESCRIPTION
掲題どおり。 https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v4.0.0 で ESM-only になって npm run lint がこけるようになったのを修正します。

本質的には renovate の更新時にテストできるようにすべきですが、いったん不具合のみ対応しています。

修正自明につきセルフマージします。
