### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,12 @@
     "testMatch": [
       "<rootDir>/tests/*.spec.ts"
     ]
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.